### PR TITLE
403 http code included for 'gerrit test connection' and some additional environment variables added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV GERRIT_USERNAME gerrit
 ENV GERRIT_PASSWORD gerrit
 ENV JENKINS_USERNAME jenkins
 ENV JENKINS_PASSWORD jenkins
+ENV JENKINS_PREFIX jenkins
+ENV GERRIT_PREFIX gerrit
 
 # Override entrypoint script
 USER root

--- a/resources/scripts/create_user.sh
+++ b/resources/scripts/create_user.sh
@@ -4,7 +4,7 @@ set -e
 # Usage
 usage() {
     echo "Usage:"
-    echo "    ${0} -u <USER> -p <PASSWORD>"
+    echo "    ${0} -u <USER> -p <PASSWORD> -b <GERRIT_PREFIX>"
     exit 1
 }
 
@@ -12,10 +12,13 @@ usage() {
 SLEEP_TIME=10
 MAX_RETRY=10
 
-while getopts "c:p:k:u:" opt; do
+while getopts "c:p:k:u:b:" opt; do
   case $opt in
     u)
       username=${OPTARG}
+      ;;
+    b)
+      gerrit_prefix=${OPTARG}
       ;;
     p)
       password=${OPTARG}
@@ -27,13 +30,13 @@ while getopts "c:p:k:u:" opt; do
   esac
 done
 
-if [ -z "${username}" ] || [ -z "${password}" ]; then
+if [ -z "${username}" ] || [ -z "${password}" ] || [ -z "${gerrit_prefix}" ]; then
     echo "Parameters missing"
     usage
 fi
 
 echo "Testing Gerrit Connection"
-until curl -sL -w "%{http_code}\\n" "http://localhost:8080/gerrit/login/%23/q/status:open" -o /dev/null | grep "401" &> /dev/null
+until curl -sL -w "%{http_code}\\n" "http://localhost:8080/${gerrit_prefix}/login/%23/q/status:open" -o /dev/null | grep "401\|403" &> /dev/null
 do
     echo "Gerrit unavailable, sleeping for ${SLEEP_TIME}"
     sleep "${SLEEP_TIME}"
@@ -43,7 +46,7 @@ echo "Creating user: ${username}"
 count=0
 until [ $count -ge ${MAX_RETRY} ]
 do
-  ret=$(curl -X POST --data "username=${username}&password=${password}" --write-out "%{http_code}" --silent --output /dev/null http://localhost:8080/gerrit/login/%23/q/status:open)
+  ret=$(curl -X POST --data "username=${username}&password=${password}" --write-out "%{http_code}" --silent --output /dev/null http://localhost:8080/${gerrit_prefix}/login/%23/q/status:open)
   # | grep 302  &> /dev/null && break
   [[ ${ret} -eq 302  ]] && break
   count=$[$count+1]

--- a/resources/scripts/gerrit_init.sh
+++ b/resources/scripts/gerrit_init.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-/var/gerrit/adop\_scripts/create\_user.sh -u ${GERRIT_USERNAME} -p ${GERRIT_PASSWORD}
-/var/gerrit/adop\_scripts/create\_user.sh -u ${JENKINS_USERNAME} -p ${JENKINS_PASSWORD}
-/var/gerrit/adop\_scripts/create\_user.sh -u ${INITIAL_ADMIN_USER} -p ${INITIAL_ADMIN_PASSWORD}
-/var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${GERRIT_USERNAME} -P ${GERRIT_PASSWORD} -u ${JENKINS_USERNAME} -g Administrators
-/var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${GERRIT_USERNAME} -P ${GERRIT_PASSWORD} -u ${INITIAL_ADMIN_USER} -g "Administrators"
+/var/gerrit/adop\_scripts/create\_user.sh -u ${GERRIT_USERNAME} -p ${GERRIT_PASSWORD} -b ${GERRIT_PREFIX}
+/var/gerrit/adop\_scripts/create\_user.sh -u ${JENKINS_USERNAME} -p ${JENKINS_PASSWORD} -b ${GERRIT_PREFIX}
+/var/gerrit/adop\_scripts/create\_user.sh -u ${INITIAL_ADMIN_USER} -p ${INITIAL_ADMIN_PASSWORD} -b ${GERRIT_PREFIX}
+/var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${GERRIT_USERNAME} -P ${GERRIT_PASSWORD} -u ${JENKINS_USERNAME} -b ${GERRIT_PREFIX} -g Administrators
+/var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${GERRIT_USERNAME} -P ${GERRIT_PASSWORD} -u ${INITIAL_ADMIN_USER} -b ${GERRIT_PREFIX} -g "Administrators"
 
-/var/gerrit/adop\_scripts/upload_ssh_key.sh -c jenkins -p 8080 -A ${JENKINS_USERNAME} -P ${JENKINS_PASSWORD} -k id_rsa.pub -u self
+/var/gerrit/adop\_scripts/upload_ssh_key.sh -c jenkins -p 8080 -A ${JENKINS_USERNAME} -P ${JENKINS_PASSWORD} -b ${GERRIT_PREFIX} -j ${JENKINS_PREFIX} -k id_rsa.pub -u self
 
 exit 0

--- a/resources/scripts/upload_ssh_key.sh
+++ b/resources/scripts/upload_ssh_key.sh
@@ -4,14 +4,14 @@ set -e
 # Usage
 usage() {
     echo "Usage:"
-    echo "    ${0} -c <host> -p <port> -A <username> -P <password> -k <KEY> -u <USER>"
+    echo "    ${0} -c <host> -p <port> -A <username> -P <password> -b <GERRIT_PREFIX> -j <JENKINS_PREFIX> -k <KEY> -u <USER>"
     exit 1
 }
 
 # Constants
 SLEEP_TIME=10
 
-while getopts "c:p:A:P:k:u:" opt; do
+while getopts "c:p:A:P:b:j:k:u:" opt; do
   case $opt in
     c)
       host=${OPTARG}
@@ -24,6 +24,12 @@ while getopts "c:p:A:P:k:u:" opt; do
       ;;
     P)
       password=${OPTARG}
+      ;;
+    b)
+      gerrit_prefix=${OPTARG}
+      ;;
+    j)
+      jenkins_prefix=${OPTARG}
       ;;
     k)
       key=${OPTARG}
@@ -38,7 +44,7 @@ while getopts "c:p:A:P:k:u:" opt; do
   esac
 done
 
-if [ -z "${host}" ] || [ -z "${port}" ] || [ -z "${username}" ] || [ -z "${password}" ] || [ -z "${key}" ] || [ -z "${user}" ]; then
+if [ -z "${host}" ] || [ -z "${port}" ] || [ -z "${username}" ] || [ -z "${password}" ] || [ -z "${gerrit_prefix}" ] || [ -z "${jenkins_prefix}" ] || [ -z "${key}" ] || [ -z "${user}" ]; then
     echo "Parameters missing"
     usage
 fi
@@ -46,17 +52,17 @@ fi
 echo "Testing Jenkins Connection & Key Presence"
 until curl -sL --output /dev/null --silent --write-out "%{http_code}\\n" \
     -u ${username}:${password} \
-    "http://${host}:${port}/jenkins/userContent/${key}" -o /dev/null | grep "200" &> /dev/null
+    "http://${host}:${port}/${jenkins_prefix}/userContent/${key}" -o /dev/null | grep "200" &> /dev/null
 do
     echo "Jenkins or key unavailable, sleeping for ${SLEEP_TIME}"
     sleep "${SLEEP_TIME}"
 done
 
 echo "Retrieving value: ${key}"
-ssh_key=$(curl -s -X GET -u ${username}:${password} "http://${host}:${port}/jenkins/userContent/${key}")
+ssh_key=$(curl -s -X GET -u ${username}:${password} "http://${host}:${port}/${jenkins_prefix}/userContent/${key}")
 
 echo "Checking if \"${user}\" exists"
-if curl -sL -w "%{http_code}\\n" "http://localhost:8080/gerrit/accounts/${user}" -o /dev/null | grep "404" &> /dev/null; then
+if curl -sL -w "%{http_code}\\n" "http://localhost:8080/${gerrit_prefix}/accounts/${user}" -o /dev/null | grep "404" &> /dev/null; then
     echo "User does not exist: ${user}"
     exit 1
 fi
@@ -64,9 +70,9 @@ fi
 echo "*** Verify key already exists... Gerrit does not do this ..."
 # Download the stored key and decode from to UTF-8 using echo -e the -n switch from echo allows to remove the trailing \n that echo would add.
 # The decode part is necessary as Gerrit correctly encode the SSH key and as a result = sign is converted to \u003d
-stored_key=$(echo -e $(curl -u ${username}:${password} --silent http://localhost:8080/gerrit/a/accounts/self/sshkeys | grep "ssh_public_key" | awk '{split($0, a, ": "); print a[2]}' | sed 's/[",]//g'))
+stored_key=$(echo -e $(curl -u ${username}:${password} --silent http://localhost:8080/${gerrit_prefix}/a/accounts/self/sshkeys | grep "ssh_public_key" | awk '{split($0, a, ": "); print a[2]}' | sed 's/[",]//g'))
 echo "****** Found stored key, verify if is same are downloaded ..."
 [[ "$stored_key" == "$ssh_key" ]] && exit 0 || echo "****** Stored key is not same as downloaded, uploading it ..."
 
 echo "Uploading key to Gerrit user \"${user}\""
-curl -X POST -u "${username}:${password}" -d "${ssh_key}" "http://localhost:8080/gerrit/a/accounts/${user}/sshkeys"
+curl -X POST -u "${username}:${password}" -d "${ssh_key}" "http://localhost:8080/${gerrit_prefix}/a/accounts/${user}/sshkeys"


### PR DESCRIPTION
The create_user.sh script has been modified to search for additional http code: 403 during "Testing Gerrit Connection". This is so the script can continue to run if HTTP_LDAP auth is used and http code 401 is not sent.

The JENKINS_PREFIX and GERRIT_PREFIX variables are used to give more flexibility when curling for URLs where the prefix can be modified if used with proxy forwarding.
