### PR TITLE
Changes for AD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV JENKINS_USERNAME jenkins
 ENV JENKINS_PASSWORD jenkins
 ENV JENKINS_PREFIX jenkins
 ENV GERRIT_PREFIX gerrit
+ENV LDAP_PROTOCOL=ldap ADOP_INTERNAL_LDAP=true
 
 # Override entrypoint script
 USER root

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ docker run --name <your-container-name> -d -p 8080:8080 -p 29418:29418 accenture
 ```
 after the above gerrit will be available at: http://localhost:8080
 
+Runtime configuration can be provided using environment variables:
+
+* ADOP_INTERNAL_LDAP, Allowed values true(default) and false. This parameter identifies whether ADOP internal LDAP is used or not. If set to false, required local users are created in gerrit.
+* LDAP_PROTOCOL, allowed values ldap(default) and ldaps
+
 ## Run docker-gerrit with MySQL and OpenLDAP
 The following assumes that MySQL and OpenLDAP are running.
 
@@ -25,7 +30,7 @@ The following command will run adop-gerrit and connect it to MySQL and OpenLDAP
   -p 8080:8080 \
   -p 29418:29418 \
   -e DATABASE_TYPE=mysql \
-  -e DB_HOSTNAME=<mysql-servername> 
+  -e DB_HOSTNAME=<mysql-servername>
   -e DB\_PORT="3306"
   -e DB\_NAME=<mysql-dbame>
   -e DB\_USER=<mysql-dbuser>
@@ -49,7 +54,7 @@ Support for older versions (down to 1.6) is provided on a best-effort basis.
 # User feedback
 
 ## Documentation
-Documentation for this image is available in the [Gerrit documenation page](https://gerrit-review.googlesource.com/Documentation/config-gerrit.html). 
+Documentation for this image is available in the [Gerrit documenation page](https://gerrit-review.googlesource.com/Documentation/config-gerrit.html).
 Additional documentaion can be found under the [`docker-library/docs` GitHub repo](https://github.com/docker-library/docs). Be sure to familiarize yourself with the [repository's `README.md` file](https://github.com/docker-library/docs/blob/master/README.md) before attempting a pull request.
 
 ## Issues

--- a/resources/gerrit-entrypoint.sh
+++ b/resources/gerrit-entrypoint.sh
@@ -45,7 +45,7 @@ if [ "$1" = '/var/gerrit/gerrit-start.sh' ]; then
   if [ "${AUTH_TYPE}" = 'LDAP' ] || [ "${AUTH_TYPE}" = 'HTTP_LDAP' ]; then
     git config -f "${GERRIT_SITE}/etc/gerrit.config" auth.type "${AUTH_TYPE}"
     git config -f "${GERRIT_SITE}/etc/gerrit.config" auth.gitBasicAuth true
-    [ -z "${LDAP_SERVER}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.server "ldap://${LDAP_SERVER}"
+    [ -z "${LDAP_SERVER}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.server "${LDAP_PROTOCOL}://${LDAP_SERVER}"
     [ -z "${LDAP_SSLVERIFY}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.sslVerify "${LDAP_SSLVERIFY}"
     [ -z "${LDAP_GROUPSVISIBLETOALL}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.groupsVisibleToAll "${LDAP_GROUPSVISIBLETOALL}"
     [ -z "${LDAP_USERNAME}" ] || git config -f "${GERRIT_SITE}/etc/gerrit.config" ldap.username "${LDAP_USERNAME}"

--- a/resources/scripts/gerrit_init.sh
+++ b/resources/scripts/gerrit_init.sh
@@ -1,13 +1,38 @@
 #!/bin/bash
 
 set -e
+#
+if [ ${ADOP_INTERNAL_LDAP} = false ]; then
+  # Execute when we are using not ADOP LDAP. It means that LDAP don't have local Jenkins and Gerrit users so we need to create.
 
-/var/gerrit/adop\_scripts/create\_user.sh -u ${GERRIT_USERNAME} -p ${GERRIT_PASSWORD} -b ${GERRIT_PREFIX}
-/var/gerrit/adop\_scripts/create\_user.sh -u ${JENKINS_USERNAME} -p ${JENKINS_PASSWORD} -b ${GERRIT_PREFIX}
-/var/gerrit/adop\_scripts/create\_user.sh -u ${INITIAL_ADMIN_USER} -p ${INITIAL_ADMIN_PASSWORD} -b ${GERRIT_PREFIX}
-/var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${GERRIT_USERNAME} -P ${GERRIT_PASSWORD} -u ${JENKINS_USERNAME} -b ${GERRIT_PREFIX} -g Administrators
-/var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${GERRIT_USERNAME} -P ${GERRIT_PASSWORD} -u ${INITIAL_ADMIN_USER} -b ${GERRIT_PREFIX} -g "Administrators"
+  # To get only username we need to trim ${LDAP_USERNAME} because it comes with BASE_DN.
+  _LDAP_USERNAME=$(echo ${LDAP_USERNAME} | awk -F ',' '{print $1}' | grep -o -P '(?<=cn=)(.+)')
+  # Activate LDAP user in Gerrit.
+  /var/gerrit/adop\_scripts/create\_user.sh -u ${_LDAP_USERNAME} -p ${LDAP_PASSWORD} -b ${GERRIT_PREFIX}
 
-/var/gerrit/adop\_scripts/upload_ssh_key.sh -c jenkins -p 8080 -A ${JENKINS_USERNAME} -P ${JENKINS_PASSWORD} -b ${GERRIT_PREFIX} -j ${JENKINS_PREFIX} -k id_rsa.pub -u self
+  # Activate INITIAL_ADMIN_USER in Gerrit.
+  /var/gerrit/adop\_scripts/create\_user.sh -u ${INITIAL_ADMIN_USER} -p ${INITIAL_ADMIN_PASSWORD} -b ${GERRIT_PREFIX}
+  # Set INITIAL_ADMIN_USER as Administrator.
+  /var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${_LDAP_USERNAME} -P ${LDAP_PASSWORD} -u ${INITIAL_ADMIN_USER} -b ${GERRIT_PREFIX} -g Administrators
+
+  # Creating local Jenkins and Gerrit users.
+  curl -X PUT -u "${INITIAL_ADMIN_USER}:${INITIAL_ADMIN_PASSWORD}" -H "Content-Type: application/json" -d '{ "name": "Jenkins", "email": "jenkins@ldap.example.com", "groups": [ "Administrators" ] }' "http://localhost:8080/${GERRIT_PREFIX}/a/accounts/jenkins"
+  curl -X PUT -u "${INITIAL_ADMIN_USER}:${INITIAL_ADMIN_PASSWORD}" -H "Content-Type: application/json" -d '{ "name": "Gerrit", "groups": [ "Administrators" ] }' "http://localhost:8080/${GERRIT_PREFIX}/a/accounts/gerrit"
+
+  # Uploading public key to Jenkins and Gerrit user.
+  /var/gerrit/adop\_scripts/upload_ssh_key.sh -c jenkins -p 8080 -A ${INITIAL_ADMIN_USER} -P ${INITIAL_ADMIN_PASSWORD} -b ${GERRIT_PREFIX} -j ${JENKINS_PREFIX} -k id_rsa.pub -u jenkins
+  /var/gerrit/adop\_scripts/upload_ssh_key.sh -c jenkins -p 8080 -A ${INITIAL_ADMIN_USER} -P ${INITIAL_ADMIN_PASSWORD} -b ${GERRIT_PREFIX} -j ${JENKINS_PREFIX} -k id_rsa.pub -u gerrit
+else
+  # Execute when we are using ADOP LDAP.
+
+  /var/gerrit/adop\_scripts/create\_user.sh -u ${GERRIT_USERNAME} -p ${GERRIT_PASSWORD} -b ${GERRIT_PREFIX}
+  /var/gerrit/adop\_scripts/create\_user.sh -u ${JENKINS_USERNAME} -p ${JENKINS_PASSWORD} -b ${GERRIT_PREFIX}
+  /var/gerrit/adop\_scripts/create\_user.sh -u ${INITIAL_ADMIN_USER} -p ${INITIAL_ADMIN_PASSWORD} -b ${GERRIT_PREFIX}
+  /var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${GERRIT_USERNAME} -P ${GERRIT_PASSWORD} -u ${JENKINS_USERNAME} -b ${GERRIT_PREFIX} -g Administrators
+  /var/gerrit/adop\_scripts/add\_user\_to\_group.sh -A ${GERRIT_USERNAME} -P ${GERRIT_PASSWORD} -u ${INITIAL_ADMIN_USER} -b ${GERRIT_PREFIX} -g "Administrators"
+
+  /var/gerrit/adop\_scripts/upload_ssh_key.sh -c jenkins -p 8080 -A ${JENKINS_USERNAME} -P ${JENKINS_PASSWORD} -b ${GERRIT_PREFIX} -j ${JENKINS_PREFIX} -k id_rsa.pub -u self
+
+fi
 
 exit 0


### PR DESCRIPTION
* Set env variable for ldap protocol. Default value: ldap
* Set env which asks what ldap connection will be - external or internal. By default, it will use internal. 
  * If external ldap is used, then it creates local jenkins and gerrit user with admin privileges. 